### PR TITLE
Migrate from ansible-runner image to python image

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,3 +1,5 @@
-FROM quay.io/ansible/ansible-runner:stable-2.12-latest
-COPY ./ssh_key /runner/env/ssh_key
-ENV ANSIBLE_TIMEOUT=120
+FROM python:3.13.0-alpine
+RUN apk add --no-cache git openssh-client
+RUN pip install ansible
+WORKDIR /app
+COPY ./ssh_key /app/env/ssh_key

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -2,7 +2,7 @@
 - hosts: all
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
   collections:
     - namelivia.monorepo
 
@@ -16,7 +16,7 @@
 - hosts: digitalocean
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
   collections:
     - namelivia.monorepo
 
@@ -83,7 +83,7 @@
 - hosts: azure
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
 
   collections:
     - namelivia.monorepo
@@ -157,7 +157,7 @@
 - hosts: lightsail
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
 
   collections:
     - namelivia.monorepo
@@ -332,7 +332,7 @@
 - hosts: bastion
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
   collections:
     - namelivia.monorepo
 
@@ -368,7 +368,7 @@
 - hosts: seedbox2
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
   collections:
     - namelivia.monorepo
   roles:
@@ -462,7 +462,7 @@
 - hosts: retropie
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
   collections:
     - namelivia.monorepo
   roles:
@@ -478,7 +478,7 @@
 - hosts: lenovo
   become: true
   vars_files:
-    - /vars/variables.yml
+    - /app/vars/variables.yml
   collections:
     - namelivia.monorepo
   roles:

--- a/bash/ansible.sh
+++ b/bash/ansible.sh
@@ -10,10 +10,10 @@ list_hosts() {
         docker run \
             -it \
             -v "$(pwd)/hosts:/etc/ansible/hosts" \
-            -v "$(pwd)/main.yml:/runner/main.yml" \
-            -v "$(pwd)/requirements.yml:/runner/requirements.yml" \
-            -v "$(pwd)/vars:/vars" \
-            -v "ansible:/home/runner/.ansible" \
+            -v "$(pwd)/main.yml:/app/main.yml" \
+            -v "$(pwd)/requirements.yml:/app/requirements.yml" \
+            -v "$(pwd)/vars:/app/vars" \
+            -v "ansible:/root/.ansible" \
             ansible ansible-inventory --list | jq -r '.hosts.hosts[]'
     )
     selectedHosts=$(echo "all $hosts" | tr ' ' '\n' | gum filter --no-limit)
@@ -24,11 +24,11 @@ list_tags() {
         docker run \
             -it \
             -v "$(pwd)/hosts:/etc/ansible/hosts" \
-            -v "$(pwd)/main.yml:/runner/main.yml" \
-            -v "$(pwd)/requirements.yml:/runner/requirements.yml" \
-            -v "$(pwd)/vars:/vars" \
-            -v "ansible:/home/runner/.ansible" \
-            ansible ansible-playbook /runner/main.yml --list-tags
+            -v "$(pwd)/main.yml:/app/main.yml" \
+            -v "$(pwd)/requirements.yml:/app/requirements.yml" \
+            -v "$(pwd)/vars:/app/vars" \
+            -v "ansible:/root/.ansible" \
+            ansible ansible-playbook /app/main.yml --list-tags
     )
     if [ $? -ne 0 ]; then
         echo $listTagsOutput
@@ -55,20 +55,20 @@ run_ansible() {
         docker run \
             -it \
             -v "$(pwd)/hosts:/etc/ansible/hosts" \
-            -v "$(pwd)/main.yml:/runner/main.yml" \
-            -v "$(pwd)/requirements.yml:/runner/requirements.yml" \
-            -v "$(pwd)/vars:/vars" \
-            -v "ansible:/home/runner/.ansible" \
-            ansible ansible-galaxy install -f -r /runner/requirements.yml \
+            -v "$(pwd)/main.yml:/app/main.yml" \
+            -v "$(pwd)/requirements.yml:/app/requirements.yml" \
+            -v "$(pwd)/vars:/app/vars" \
+            -v "ansible:/root/.ansible" \
+            ansible ansible-galaxy install -f -r /app/requirements.yml \
     ) && \
     (cd ansible && \
         docker run \
             -it \
             -v "$(pwd)/hosts:/etc/ansible/hosts" \
-            -v "$(pwd)/main.yml:/runner/main.yml" \
-            -v "$(pwd)/requirements.yml:/runner/requirements.yml" \
-            -v "$(pwd)/vars:/vars" \
-            -v "ansible:/home/runner/.ansible" \
-            ansible ansible-playbook /runner/main.yml --key-file /runner/env/ssh_key --ssh-common-args='-o StrictHostKeyChecking=no' $tagsOption $hostsOption
+            -v "$(pwd)/main.yml:/app/main.yml" \
+            -v "$(pwd)/requirements.yml:/app/requirements.yml" \
+            -v "$(pwd)/vars:/app/vars" \
+            -v "ansible:/root/.ansible" \
+            ansible ansible-playbook /app/main.yml --key-file /app/env/ssh_key --ssh-common-args='-o StrictHostKeyChecking=no' $tagsOption $hostsOption
     )
 }


### PR DESCRIPTION
The ansible version was stuck in the past on `quay.io/ansible/ansible-runner:stable-2.12-latest` as this was the latest version of the now abandoned ansible-runner docker. I actually don't need it, I can use a plain docker image and install ansible on it.